### PR TITLE
Add share url and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ FA_SITE_ID="YOUR-SITE_ID"
 FA_HOSTNAME="your-hostname"
 ```
 
+You can also manage your hostnames in the config file:
+
+Start by publishing the config
+
+```sh
+php artisan vendor:publish --tag="fa-widget-config"
+```
+
+Then add your hostnames in the "hostnames" array (if empty, it will get for all)
+
+```php
+'hostnames' => [
+    'https://my-hostname.com'
+    'https://my-other-hostname.com'
+]
+```
+
 You also need to add the widget to the widget array in config/statamic/cp.php file, as you would with [any other widget](https://statamic.dev/widgets#configuration).
 
 ```php

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ php artisan vendor:publish --tag="fa-widget-config"
 
 Then add your hostnames in the "hostnames" array (if empty, it will get for all)
 
+> If you have multiple hostnames there may appear to be "duplicate" entries, but they are not because they are pointing to different hostnames.
+
 ```php
 'hostnames' => [
     'https://my-hostname.com'

--- a/config/fa.php
+++ b/config/fa.php
@@ -3,6 +3,8 @@
 return [
     'api_token' => env('FA_API_TOKEN', null),
     'site_id' => env('FA_SITE_ID', null),
-    'hostname' => env('FA_HOSTNAME', null),
+    'hostnames' => [
+        env('FA_HOSTNAME'),
+    ],
     'share_url' => env('FA_SHARE_URL', null),
 ];

--- a/config/fa.php
+++ b/config/fa.php
@@ -4,4 +4,5 @@ return [
     'api_token' => env('FA_API_TOKEN', null),
     'site_id' => env('FA_SITE_ID', null),
     'hostname' => env('FA_HOSTNAME', null),
+    'share_url' => env('FA_SHARE_URL', null),
 ];

--- a/config/fa.php
+++ b/config/fa.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'fa_api_token' => env('FA_API_TOKEN', null),
-    'fa_site_id' => env('FA_SITE_ID', null),
-    'fa_hostname' => env('FA_HOSTNAME', null),
+    'api_token' => env('FA_API_TOKEN', null),
+    'site_id' => env('FA_SITE_ID', null),
+    'hostname' => env('FA_HOSTNAME', null),
 ];

--- a/resources/views/widgets/fa.blade.php
+++ b/resources/views/widgets/fa.blade.php
@@ -3,6 +3,6 @@
 </div>
 <div class="text-center text-xs p-4">
     <span>Want more stats? </span>
-    <a href="https://app.usefathom.com/?site={{ config('fa.site_id') }}" target="blank" class="ml-1 underline">Visit
+    <a href="{{ config('fa.share_url') ?? "https://app.usefathom.com/?site=".config('fa.site_id') }}" target="blank" class="ml-1 underline">Visit
         Fathom Analytics</a>
 </div>

--- a/resources/views/widgets/fa.blade.php
+++ b/resources/views/widgets/fa.blade.php
@@ -1,8 +1,8 @@
 <div class="card p-0 overflow-hidden">
-    <fa-widget site-id="{{ config('fa.fa_site_id') }}"></fa-widget>
+    <fa-widget site-id="{{ config('fa.site_id') }}"></fa-widget>
 </div>
 <div class="text-center text-xs p-4">
     <span>Want more stats? </span>
-    <a href="https://app.usefathom.com/?site={{ config('fa.fa_site_id') }}" target="blank" class="ml-1 underline">Visit
+    <a href="https://app.usefathom.com/?site={{ config('fa.site_id') }}" target="blank" class="ml-1 underline">Visit
         Fathom Analytics</a>
 </div>

--- a/src/Http/Controllers/FAController.php
+++ b/src/Http/Controllers/FAController.php
@@ -4,6 +4,7 @@ namespace Itiden\FA\Http\Controllers;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Routing\Controller;
@@ -41,18 +42,18 @@ class FAController extends Controller
                 'limit' => 100,
                 'sort_by' => $sortOrder,
                 'date_from' => $interval,
-                'filters' => json_encode([
+                'filters' => json_encode(collect(config('fa.hostnames'))->filter()->map(fn ($hostname) => [
                     [
                         'property' => 'hostname',
                         'operator' => 'is',
-                        'value' => config('fa.hostname'),
+                        'value' => $hostname,
                     ],
-                ]),
+                ])),
             ])
             ->collect());
 
         if ($response->has('errors')) {
-            throw new \Exception('Something went wrong when getting analytics data');
+            throw new Exception('Something went wrong when getting analytics data');
         }
 
         $editedResponse = $response->map(function ($item) {

--- a/src/Http/Controllers/FAController.php
+++ b/src/Http/Controllers/FAController.php
@@ -51,6 +51,10 @@ class FAController extends Controller
             ])
             ->collect());
 
+        if ($response->has('errors')) {
+            throw new \Exception('Something went wrong when getting analytics data');
+        }
+
         $editedResponse = $response->map(function ($item) {
             if ($item['pathname'] != '/' && str_ends_with($item['pathname'], '/')) {
                 $item['pathname'] = rtrim($item['pathname'], '/');

--- a/src/Http/Controllers/FAController.php
+++ b/src/Http/Controllers/FAController.php
@@ -42,13 +42,14 @@ class FAController extends Controller
                 'limit' => 100,
                 'sort_by' => $sortOrder,
                 'date_from' => $interval,
-                'filters' => json_encode(collect(config('fa.hostnames'))->filter()->map(fn ($hostname) => [
+                'filters' => json_encode(collect(config('fa.hostnames'))->filter()->map(
+                    fn ($hostname) =>
                     [
                         'property' => 'hostname',
                         'operator' => 'is',
                         'value' => $hostname,
                     ],
-                ])),
+                )),
             ])
             ->collect());
 

--- a/src/Http/Controllers/FAController.php
+++ b/src/Http/Controllers/FAController.php
@@ -29,16 +29,16 @@ class FAController extends Controller
             default => null
         };
 
-        $response = Cache::remember('fathom' . $sortOrder . $interval, 60, fn () => Http::withToken(config('fa.fa_api_token'))
+        $response = Cache::remember('fathom' . $sortOrder . $interval, 60, fn () => Http::withToken(config('fa.api_token'))
             ->get('https://api.usefathom.com/v1/aggregations', [
                 'entity' => 'pageview',
-                'entity_id' => config('fa.fa_site_id'),
+                'entity_id' => config('fa.site_id'),
                 'aggregates' => 'visits, uniques, pageviews, avg_duration, bounce_rate',
                 'field_grouping' => 'hostname,pathname',
                 'limit' => 100,
                 'sort_by' => $sortOrder,
                 'date_from' => $interval,
-                'filters' => '[{"property":"hostname","operator":"is","value":"' . config('fa.fa_hostname') . '"}]',
+                'filters' => '[{"property":"hostname","operator":"is","value":"' . config('fa.hostname') . '"}]',
             ])
             ->collect());
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,7 +38,8 @@ class ServiceProvider extends AddonServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/fa.php', 'fa'
+            __DIR__ . '/../config/fa.php',
+            'fa'
         );
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -29,7 +29,7 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->publishes([
             __DIR__ . '/../config/fa.php' => config_path('fa.php'),
-        ]);
+        ], 'fa-widget-config');
     }
 
     /**


### PR DESCRIPTION
- Fix formatting
- Remove `fa_` prefix from config keys since they are already prefixed with `fa.` when retrieving.
- Make filters an array so it is easier to understand what is going on there.
- Add option to use a share url (#1, #2), I see that there could be a need for a password, but I'm not to sure how it should be displayed.
- Fix error when the Fathom api is returning errors, before you got "array key is not defined".
- Refactor to use collection methods instead of array, and removed some parameters from the `LengthAwarePaginator` since it automatically resolves the `?page` parameter and converts the `$items` to a collection internally anyways.
- Add support for multiple or no hostnames
